### PR TITLE
docs: Correct version README.md links.

### DIFF
--- a/internal/version/README.md
+++ b/internal/version/README.md
@@ -1,9 +1,8 @@
 version
 =======
 
-[![Build Status](https://github.com/decred/dcrd/workflows/Build%20and%20Test/badge.svg)](https://github.com/decred/dcrd/actions)
 [![ISC License](https://img.shields.io/badge/license-ISC-blue.svg)](http://copyfree.org)
-[![Doc](https://img.shields.io/badge/doc-reference-blue.svg)](https://pkg.go.dev/github.com/decred/dcrd/internal/version)
+[![Doc](https://img.shields.io/badge/doc-reference-blue.svg)](https://pkg.go.dev/github.com/decred/dcrlnlpd/internal/version)
 
 Package version provides a single location to house the version information for
 dcrd and other utilities provided in the same repository.


### PR DESCRIPTION
This also removes the build status since actions are not yet configured
for the repo.