### PR TITLE
multi: Improve handling for pending requests

### DIFF
--- a/dcrlnpd.conf
+++ b/dcrlnpd.conf
@@ -86,6 +86,10 @@
 ; Key to restrict access to channel creation.
 ; openpolicy.key = some_secret_key
 
+; How long invoices to open a channel are valid for. Also controls how long
+; a client must wait before requesting a new invoice.
+; openpolicy.invoiceexpiration = 1h
+
 
 [Close Channel Policy]
 


### PR DESCRIPTION
This PR attempts to improve handling for pending requests in two ways:

- The first commit adds sanity checks on the client side, to avoid requesting an invoice when it's unlikely to be payable
- The second commit parametrizes the invoice expiration on the server side, to allow LPD operators to specify their desired expiration policy