### PR TITLE
Fix grpc reconnection and add /info endpoint

### DIFF
--- a/main.go
+++ b/main.go
@@ -23,6 +23,12 @@ func indexHandler(w http.ResponseWriter, req *http.Request) {
 
 func newInfoHandler(server *server.Server) func(w http.ResponseWriter, req *http.Request) {
 	return func(w http.ResponseWriter, req *http.Request) {
+		if !isReqFromLocalhost(req) {
+			w.WriteHeader(http.StatusForbidden)
+			log.Warnf("Forbidden request for info from %s", requestAddr(req))
+			return
+		}
+
 		info, err := server.FetchManagedChannels(req.Context())
 		if err != nil {
 			w.WriteHeader(http.StatusInternalServerError)

--- a/server/chanscore.go
+++ b/server/chanscore.go
@@ -2,7 +2,7 @@ package server
 
 import "time"
 
-// chanActivityScore holds "how much activity" a channel received through some
+// ChanActivityScore holds "how much activity" a channel received through some
 // period of time.
 //
 // The basic equation for determining the "activity" score for a channel is
@@ -12,17 +12,17 @@ import "time"
 // The interpretation for this equation is that the activity score is the
 // percentage of the channel capacity sent through the channel during its
 // entire lifetime.
-type chanActivityScore float64
+type ChanActivityScore float64
 
 // toPercent returns the activity score as a percentage.
-func (s chanActivityScore) toPercent() float64 {
+func (s ChanActivityScore) ToPercent() float64 {
 	return float64(s) * 100
 }
 
 // channelActivity returns the "activity" score for a channel, which measures
 // the total amount of atoms sent through the channel during its lifetime.
 func channelActivity(totalSentAtoms, channelSizeAtoms int64,
-	lifetime time.Duration) chanActivityScore {
+	lifetime time.Duration) ChanActivityScore {
 
 	if lifetime <= 0 {
 		panic("lifetime cannot be <= 0")
@@ -37,5 +37,5 @@ func channelActivity(totalSentAtoms, channelSizeAtoms int64,
 		hours = 1
 	}
 
-	return chanActivityScore(float64(totalSentAtoms) / float64(channelSizeAtoms) / hours)
+	return ChanActivityScore(float64(totalSentAtoms) / float64(channelSizeAtoms) / hours)
 }

--- a/server/chanscore_test.go
+++ b/server/chanscore_test.go
@@ -14,7 +14,7 @@ func TestChanActivityScore(t *testing.T) {
 		sent int64
 		size int64
 		life time.Duration
-		want chanActivityScore
+		want ChanActivityScore
 	}{{
 		name: "1 atom sent through 1 DCR chan within 1 hour",
 		sent: 1,

--- a/util.go
+++ b/util.go
@@ -1,10 +1,58 @@
 package main
 
 import (
+	"net"
+	"net/http"
 	"strings"
 
 	"github.com/gorilla/mux"
 )
+
+func requestAddr(req *http.Request) string {
+	res := req.RemoteAddr
+	for _, header := range []string{"X-Forwarded-For", "X-Real-IP"} {
+		if values, ok := req.Header[header]; ok {
+			for _, value := range values {
+				res += strings.TrimSpace(value)
+			}
+		}
+	}
+
+	return res
+}
+
+// isReqFromLocalhost checks if the request came from localhost. It checks the
+// X-Forwarded-For and X-Real-IP headers first and then falls back to the
+// RemoteAddr if necessary.
+func isReqFromLocalhost(req *http.Request) bool {
+	// Function to check if an IP from a given string is a loopback address.
+	// It splits the host and port if necessary and checks the IP.
+	isLoopback := func(addr string) bool {
+		ip := net.ParseIP(addr)
+		return ip != nil && ip.IsLoopback()
+	}
+
+	// Check X-Forwarded-For and X-Real-IP headers for the original client IP
+	for _, header := range []string{"X-Forwarded-For", "X-Real-IP"} {
+		if values, ok := req.Header[header]; ok {
+			for _, value := range values {
+				for _, ipStr := range strings.Split(value, ",") {
+					ipStr = strings.TrimSpace(ipStr)
+					if isLoopback(ipStr) {
+						return true
+					}
+				}
+			}
+		}
+	}
+
+	// If the headers are not present, fall back to the RemoteAddr.
+	host, _, err := net.SplitHostPort(req.RemoteAddr)
+	if err != nil {
+		host = req.RemoteAddr
+	}
+	return isLoopback(host)
+}
 
 func logRouterConfig(r *mux.Router) {
 	err := r.Walk(func(route *mux.Route, router *mux.Router, ancestors []*mux.Route) error {


### PR DESCRIPTION
The /info endpoint is meant to offer information about the server's management of the channels to the operator. It should only be accessible from localhost.

This also fixes the gRPC connection issue #17.
