### PR TITLE
server: Add ignore policy

### DIFF
--- a/dcrlnpd.conf
+++ b/dcrlnpd.conf
@@ -112,3 +112,21 @@
 
 ; Minimum wallet balance, below which channels will begin to be closed.
 ; closepolicy.minwalletbalance = 1.0
+
+
+[Ignore Policy]
+
+; List of channel points to ignore for channel management purposes. Even if
+; these are outbound, they will NOT be closed if they don't conform to the
+; policy.
+;
+; ignorepolicy.channels = abcd...:1
+; ignorepolicy.channels = ef01...:3
+
+; List of nodes to ignore for channel management purposes. All channels that
+; were opened to one of these will be ignored. Note that this also makes LPD
+; reject requests to open channels to these, because the goal of this setting
+; is to mark these nodes as manually managed.
+;
+; ignorepolicy.nodes = abcd...
+; ignorepolicy.nodes = ef01...


### PR DESCRIPTION
The ignore policy config allows the operator to set channels and/or nodes that should not be managed by LPD. The goal for this setting is to allow manual management of select channels/nodes.